### PR TITLE
Feature/open wire check

### DIFF
--- a/Firmware/PlatformIO/main_mcu/platformio.ini
+++ b/Firmware/PlatformIO/main_mcu/platformio.ini
@@ -12,7 +12,7 @@
 platform = teensy
 board = teensy41
 framework = arduino
-lib_deps = https://github.com/NU-Formula-Racing/bq79656.git
+lib_deps = https://github.com/NU-Formula-Racing/bq79656.git#feature/open-wire-detection
     https://github.com/NU-Formula-Racing/Chargers.git
     https://github.com/NU-Formula-Racing/CAN.git
     https://github.com/NU-Formula-Racing/timers.git

--- a/Firmware/PlatformIO/main_mcu/platformio.ini
+++ b/Firmware/PlatformIO/main_mcu/platformio.ini
@@ -13,6 +13,6 @@ platform = teensy
 board = teensy41
 framework = arduino
 lib_deps = https://github.com/NU-Formula-Racing/bq79656.git
-    https://github.com/NU-Formula-Racing/GWP-Charger.git
+    https://github.com/NU-Formula-Racing/Chargers.git
     https://github.com/NU-Formula-Racing/CAN.git
     https://github.com/NU-Formula-Racing/timers.git

--- a/Firmware/PlatformIO/main_mcu/src/bms.cpp
+++ b/Firmware/PlatformIO/main_mcu/src/bms.cpp
@@ -16,9 +16,10 @@ void BMS::CheckFaults()
     overtemperature_fault_ = static_cast<BMSFault>(max_cell_temperature_ >= kOvertemp);
     undertemperature_fault_ = static_cast<BMSFault>(min_cell_temperature_ <= kUndertemp);
 
-    fault_ = static_cast<BMSFault>(static_cast<bool>(overvoltage_fault_) || static_cast<bool>(undervoltage_fault_)
-                                   || static_cast<bool>(overcurrent_fault_) || static_cast<bool>(overtemperature_fault_)
-                                   || static_cast<bool>(undertemperature_fault_));
+    fault_ =
+        static_cast<BMSFault>(static_cast<bool>(overvoltage_fault_) || static_cast<bool>(undervoltage_fault_)
+                              || static_cast<bool>(overcurrent_fault_) || static_cast<bool>(overtemperature_fault_)
+                              || static_cast<bool>(undertemperature_fault_) || static_cast<bool>(open_wire_fault_));
 }
 
 void BMS::Tick()

--- a/Firmware/PlatformIO/main_mcu/src/bms.h
+++ b/Firmware/PlatformIO/main_mcu/src/bms.h
@@ -85,15 +85,8 @@ public:
         config.callback = [this]() { this->ChangeState(BMSState::kFault); };
         watchdog_timer_.begin(config);
 
-        timer_group_.AddTimer(15000,
-                              [open_wire_check]()
-                              {
-                                  open_wire_check = bq_.RunOpenWireCheck();
-                                  if (open_wire_check == true)
-                                  {
-                                      undervoltage_fault_ = true;
-                                  }
-                              });
+        timer_group_.AddTimer(
+            15000, [this]() { this->open_wire_fault_ = static_cast<BMSFault>(this->bq_.RunOpenWireCheck()); });
     }
 
     void Tick();
@@ -123,13 +116,12 @@ public:
     BMSFault GetOverTemperatureFault() override { return overtemperature_fault_; }
     BMSFault GetOverCurrentFault() override { return overcurrent_fault_; }
     BMSFault GetExternalKillFault() override { return external_kill_fault_; }
+    BMSFault GetOpenWireFault() override { return open_wire_fault_; }
 
 private:
     BQ79656 bq_;
 
     WDT_T4<WDT1> watchdog_timer_;
-
-    boolean open_wire_check;
 
     const int kNumCellsSeries;
     const int kNumThermistors;
@@ -177,6 +169,7 @@ private:
     BMSFault overtemperature_fault_{BMSFault::kNotFaulted};
     BMSFault overcurrent_fault_{BMSFault::kNotFaulted};
     BMSFault external_kill_fault_{BMSFault::kNotFaulted};
+    BMSFault open_wire_fault_{BMSFault::kNotFaulted};
 
     static int fault_pin_;
     BMSFault fault_{BMSFault::kNotFaulted};

--- a/Firmware/PlatformIO/main_mcu/src/bms.h
+++ b/Firmware/PlatformIO/main_mcu/src/bms.h
@@ -84,6 +84,16 @@ public:
         config.timeout = 2; /* in seconds, 0->128 */
         config.callback = [this]() { this->ChangeState(BMSState::kFault); };
         watchdog_timer_.begin(config);
+
+        timer_group_.AddTimer(15000,
+                              [open_wire_check]()
+                              {
+                                  open_wire_check = bq_.RunOpenWireCheck();
+                                  if (open_wire_check == true)
+                                  {
+                                      undervoltage_fault_ = true;
+                                  }
+                              });
     }
 
     void Tick();
@@ -118,6 +128,8 @@ private:
     BQ79656 bq_;
 
     WDT_T4<WDT1> watchdog_timer_;
+
+    boolean open_wire_check;
 
     const int kNumCellsSeries;
     const int kNumThermistors;

--- a/Firmware/PlatformIO/main_mcu/src/bms_interface.h
+++ b/Firmware/PlatformIO/main_mcu/src/bms_interface.h
@@ -43,4 +43,5 @@ public:
     virtual BMSFault GetOverTemperatureFault() = 0;
     virtual BMSFault GetOverCurrentFault() = 0;
     virtual BMSFault GetExternalKillFault() = 0;
+    virtual BMSFault GetOpenWireFault() = 0;
 };


### PR DESCRIPTION
Using bq feature open-wire-detection in our libdeps, I added open_wire_fault as a BMSFault and added a timer to timer_group to check open_wire_fault's values every 15 seconds. 